### PR TITLE
fixed a check in transitionListener handler ...

### DIFF
--- a/packages/react-swipeable-views/src/SwipeableViews.js
+++ b/packages/react-swipeable-views/src/SwipeableViews.js
@@ -264,7 +264,7 @@ class SwipeableViews extends React.Component {
   componentDidMount() {
     // Subscribe to transition end events.
     this.transitionListener = addEventListener(this.containerNode, 'transitionend', event => {
-      if (event.target !== this.containerNode) {
+      if (event.target !== this.rootNode) {
         return;
       }
 


### PR DESCRIPTION
that was causing extra transition effects when interacting with other elements with transition styles in a slide.
https://github.com/oliviertassinari/react-swipeable-views/issues/656

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
